### PR TITLE
Yum fix lock

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,8 +1,8 @@
 ---
 - name: Install the required packages in Redhat derivatives
   yum:
-    name=chrony
-    state={{ chrony_pkg_state }}
+    name: chrony
+    state: "{{ chrony_pkg_state }}"
   register: yum_result
   until: yum_result is success
   retries: 3

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,6 +1,12 @@
 ---
 - name: Install the required packages in Redhat derivatives
-  yum: name=chrony state={{ chrony_pkg_state }}
+  yum:
+    name=chrony
+    state={{ chrony_pkg_state }}
+  register: yum_result
+  until: yum_result is success
+  retries: 3
+  delay: 10
 
 - name: Check if ntpd service exists
   stat: path="/usr/lib/systemd/system/ntpd.service"


### PR DESCRIPTION
As we started facing problems with the yum module (especially the lockfile taken by another process issue: https://github.com/ansible/ansible/issues/57189) we need the possibility to retry. As ansible 2.8 suggests the lock_timeout parameter the solution in this PR will work with the ansible 2.7 as well.  